### PR TITLE
Rename namespace to TurboBoulder

### DIFF
--- a/api/Controllers/AdminController.cs
+++ b/api/Controllers/AdminController.cs
@@ -1,14 +1,14 @@
-﻿using IdaWebApplicationTemplate.Data;
-using IdaWebApplicationTemplate.Services;
-using IdaWebApplicationTemplate.Settings;
-using IdaWebApplicationTemplate.Shared.DataTransferObjects;
+﻿using TurboBoulder.Data;
+using TurboBoulder.Services;
+using TurboBoulder.Settings;
+using TurboBoulder.Shared.DataTransferObjects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
-namespace IdaWebApplicationTemplate.Controllers
+namespace TurboBoulder.Controllers
 {
     [Route("api/admin")]
     [Authorize(Roles = "Admin")]

--- a/api/Controllers/UserController.cs
+++ b/api/Controllers/UserController.cs
@@ -1,7 +1,7 @@
-﻿using IdaWebApplicationTemplate;
-using IdaWebApplicationTemplate.Data;
-using IdaWebApplicationTemplate.Services;
-using IdaWebApplicationTemplate.Shared.DataTransferObjects;
+﻿using TurboBoulder;
+using TurboBoulder.Data;
+using TurboBoulder.Services;
+using TurboBoulder.Shared.DataTransferObjects;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -13,7 +13,7 @@ using System.Security.Claims;
 using System.Text;
 using System.Web;
 
-namespace IdaWebApplicationTemplate.Controllers
+namespace TurboBoulder.Controllers
 {
     [Route("api/user")]
     [ApiController]

--- a/api/Data/ApplicationDbContext.cs
+++ b/api/Data/ApplicationDbContext.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
-namespace IdaWebApplicationTemplate.Data
+namespace TurboBoulder.Data
 {
     public class ApplicationDbContext : IdentityDbContext<User>
     {

--- a/api/Data/User.cs
+++ b/api/Data/User.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
 
-namespace IdaWebApplicationTemplate.Data
+namespace TurboBoulder.Data
 {
     public class User : IdentityUser
     {

--- a/api/Data/UserProfile.cs
+++ b/api/Data/UserProfile.cs
@@ -1,4 +1,4 @@
-﻿namespace IdaWebApplicationTemplate.Data
+﻿namespace TurboBoulder.Data
 {
     public class UserProfile
     {

--- a/api/DatabaseHealthCheck.cs
+++ b/api/DatabaseHealthCheck.cs
@@ -1,7 +1,7 @@
-﻿using IdaWebApplicationTemplate.Data;
+﻿using TurboBoulder.Data;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-namespace IdaWebApplicationTemplate
+namespace TurboBoulder
 {
     public class DatabaseHealthCheck : IHealthCheck
     {

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,17 +7,17 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /src
-COPY ["IdaWebApplicationTemplate/IdaWebApplicationTemplate.csproj", "IdaWebApplicationTemplate/"]
-COPY ["IdaWebApplicationTemplate.Shared/IdaWebApplicationTemplate.Shared.csproj", "IdaWebApplicationTemplate.Shared/"]
-RUN dotnet restore "IdaWebApplicationTemplate/IdaWebApplicationTemplate.csproj"
+COPY ["api/api.csproj", "api/"]
+COPY ["shared/shared.csproj", "shared/"]
+RUN dotnet restore "api/api.csproj"
 COPY . .
-WORKDIR "/src/IdaWebApplicationTemplate"
-RUN dotnet build "IdaWebApplicationTemplate.csproj" -c Release -o /app/build
+WORKDIR "/src/api"
+RUN dotnet build "api.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "IdaWebApplicationTemplate.csproj" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "api.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "IdaWebApplicationTemplate.dll"]
+ENTRYPOINT ["dotnet", "api.dll"]

--- a/api/Middleware/ExceptionMiddleware.cs
+++ b/api/Middleware/ExceptionMiddleware.cs
@@ -1,8 +1,8 @@
-﻿using IdaWebApplicationTemplate.Utilities;
+﻿using TurboBoulder.Utilities;
 using Microsoft.Data.SqlClient;
 using System.Net;
 
-namespace IdaWebApplicationTemplate.Middleware
+namespace TurboBoulder.Middleware
 {
     public class ExceptionMiddleware
     {

--- a/api/Middleware/HeadersLoggingMiddleware.cs
+++ b/api/Middleware/HeadersLoggingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿namespace IdaWebApplicationTemplate.Middleware
+﻿namespace TurboBoulder.Middleware
 {
 
     public class HeadersLoggingMiddleware

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,16 +1,16 @@
 using Microsoft.EntityFrameworkCore;
-using IdaWebApplicationTemplate.Data;
+using TurboBoulder.Data;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.OpenApi.Models;
-using IdaWebApplicationTemplate;
-using IdaWebApplicationTemplate.Services;
-using IdaWebApplicationTemplate.Settings;
+using TurboBoulder;
+using TurboBoulder.Services;
+using TurboBoulder.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using IdaWebApplicationTemplate.Middleware;
+using TurboBoulder.Middleware;
 using Microsoft.Data.SqlClient;
 using System.Security.Cryptography.X509Certificates;
 

--- a/api/Services/EmailService.cs
+++ b/api/Services/EmailService.cs
@@ -1,4 +1,4 @@
-﻿namespace IdaWebApplicationTemplate.Services
+﻿namespace TurboBoulder.Services
 {
     public class EmailService : IEmailService
     {

--- a/api/Services/EmailTwoFactorAuthenticationService.cs
+++ b/api/Services/EmailTwoFactorAuthenticationService.cs
@@ -1,6 +1,6 @@
-﻿using IdaWebApplicationTemplate.Data;
+﻿using TurboBoulder.Data;
 
-namespace IdaWebApplicationTemplate.Services
+namespace TurboBoulder.Services
 {
     public class EmailTwoFactorAuthenticationService : ITwoFactorAuthenticationService
     {

--- a/api/Services/IEmailService.cs
+++ b/api/Services/IEmailService.cs
@@ -1,4 +1,4 @@
-﻿namespace IdaWebApplicationTemplate.Services
+﻿namespace TurboBoulder.Services
 {
     public interface IEmailService
     {

--- a/api/Services/ITwoFactorAuthentication.cs
+++ b/api/Services/ITwoFactorAuthentication.cs
@@ -1,6 +1,6 @@
-﻿using IdaWebApplicationTemplate.Data;
+﻿using TurboBoulder.Data;
 
-namespace IdaWebApplicationTemplate.Services
+namespace TurboBoulder.Services
 {
     public interface ITwoFactorAuthentication
     {

--- a/api/Services/ITwoFactorAuthenticationService.cs
+++ b/api/Services/ITwoFactorAuthenticationService.cs
@@ -1,6 +1,6 @@
-﻿using IdaWebApplicationTemplate.Data;
+﻿using TurboBoulder.Data;
 
-namespace IdaWebApplicationTemplate.Services
+namespace TurboBoulder.Services
 {
     public interface ITwoFactorAuthenticationService
     {

--- a/api/Services/TwoFactorAuthenticationEmail.cs
+++ b/api/Services/TwoFactorAuthenticationEmail.cs
@@ -1,6 +1,6 @@
-﻿using IdaWebApplicationTemplate.Data;
+﻿using TurboBoulder.Data;
 
-namespace IdaWebApplicationTemplate.Services
+namespace TurboBoulder.Services
 {
     public class TwoFactorAuthenticationEmail : ITwoFactorAuthentication
     {

--- a/api/Settings/SecuritySettings.cs
+++ b/api/Settings/SecuritySettings.cs
@@ -1,4 +1,4 @@
-﻿namespace IdaWebApplicationTemplate.Settings
+﻿namespace TurboBoulder.Settings
 {
     public class SecuritySettings
     {

--- a/api/Utilities/ErrorDetails.cs
+++ b/api/Utilities/ErrorDetails.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace IdaWebApplicationTemplate.Utilities
+namespace TurboBoulder.Utilities
 {
     public class ErrorDetails
     {

--- a/frontend/Pages/Login.razor
+++ b/frontend/Pages/Login.razor
@@ -1,6 +1,6 @@
 ﻿@page "/login"
 @using System.ComponentModel.DataAnnotations;
-@using IdaWebApplicationTemplate.Shared.DataTransferObjects;
+@using TurboBoulder.Shared.DataTransferObjects;
 @inject HttpClient Http
 @inject NavigationManager Navigation
 

--- a/frontend/Pages/TestPage.razor
+++ b/frontend/Pages/TestPage.razor
@@ -1,7 +1,7 @@
 ﻿@page "/test"
 @using System.Net.Http
 @using System.Text.Json
-@using IdaWebApplicationTemplate.Shared.DataTransferObjects;
+@using TurboBoulder.Shared.DataTransferObjects;
 @inject HttpClient Http
 
 <h3>Test Page</h3>

--- a/shared/DataTransferObjects/DTOConfirmEmail.cs
+++ b/shared/DataTransferObjects/DTOConfirmEmail.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOConfirmEmail
     {

--- a/shared/DataTransferObjects/DTOConfirmResetPassword.cs
+++ b/shared/DataTransferObjects/DTOConfirmResetPassword.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOConfirmResetPassword
     {

--- a/shared/DataTransferObjects/DTODeleteUser.cs
+++ b/shared/DataTransferObjects/DTODeleteUser.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTODeleteUser
     {

--- a/shared/DataTransferObjects/DTOLogin.cs
+++ b/shared/DataTransferObjects/DTOLogin.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOLogin
     {

--- a/shared/DataTransferObjects/DTORegisterUser.cs
+++ b/shared/DataTransferObjects/DTORegisterUser.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTORegisterUser
     {

--- a/shared/DataTransferObjects/DTOResetPassword.cs
+++ b/shared/DataTransferObjects/DTOResetPassword.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOResetPassword
     {

--- a/shared/DataTransferObjects/DTOToken.cs
+++ b/shared/DataTransferObjects/DTOToken.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOToken
     {

--- a/shared/DataTransferObjects/DTOUpdateUser.cs
+++ b/shared/DataTransferObjects/DTOUpdateUser.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOUpdateUser
     {

--- a/shared/DataTransferObjects/DTOUserData.cs
+++ b/shared/DataTransferObjects/DTOUserData.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace IdaWebApplicationTemplate.Shared.DataTransferObjects
+namespace TurboBoulder.Shared.DataTransferObjects
 {
     public class DTOUserData
     {


### PR DESCRIPTION
## Summary
- rename IdaWebApplicationTemplate namespaces to `TurboBoulder`
- update API Dockerfile to reference current project paths

## Testing
- `dotnet build TurboBoulder.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_b_6843f1665608832bae6e1d12f6290bf8